### PR TITLE
making button only show up when both nav and menu are visible

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -85,7 +85,7 @@ define([
             }).show();
           }
 
-          if (browser.config.show_menu && (thisB.isScreenshot === false || thisB.config.dialog)) {
+          if (browser.config.show_nav && browser.config.show_menu && (thisB.isScreenshot === false || thisB.config.dialog)) {
             var button = new dijitButton({
               className: 'screenshot-button',
               innerHTML: 'Screen Shot',


### PR DESCRIPTION
It is unclear to me why this matters but if I use both nav=0 and menu=0 in a url, this plugin will crash unless I have the additional check that both exist.